### PR TITLE
Field readonly on master field change

### DIFF
--- a/Serene/Serene.Web/Modules/Common/Helpers/DialogUtils.ts
+++ b/Serene/Serene.Web/Modules/Common/Helpers/DialogUtils.ts
@@ -15,4 +15,17 @@
                 });
         });
     }
+    
+    export function readonlyOnChange(masterField: Serenity.Widget<any>, cascadeField: Serenity.Widget<any>, valueEnable: any): void {
+        DialogUtils.conditionalReadOnly(masterField, cascadeField, valueEnable);
+        masterField.change(e => { DialogUtils.conditionalReadOnly(masterField, cascadeField, valueEnable); });
+    }
+
+    export function conditionalReadOnly(masterField: Serenity.Widget<any>, cascadeField: Serenity.Widget<any>, valueEnable: any): void {
+        if (Serenity.EditorUtils.getValue(masterField) == valueEnable)
+            Serenity.EditorUtils.setReadOnly(cascadeField, false);
+        else
+            Serenity.EditorUtils.setReadOnly(cascadeField, true);
+    }
+
 }


### PR DESCRIPTION
Can this be useful? 
These two methods set readonly (or not) in according the masterField value is valueEnable.

Use, in afterLoadEntity, for example for a checkbox with a controlled field

DialogUtils.readonlyOnChange(this.form.MyMasterField, this.form.MyControlledField, true);