### PR TITLE
Minor variations

### DIFF
--- a/Serene/Serene.Web/Modules/Common/Reporting/ExcelReportGenerator.cs
+++ b/Serene/Serene.Web/Modules/Common/Reporting/ExcelReportGenerator.cs
@@ -24,9 +24,9 @@ namespace Serenity.Reporting
         {
             var package = new ExcelPackage();
             var workbook = package.Workbook;
-            var worksheet = package.Workbook.Worksheets.Add("Page1");
+            var worksheet = package.Workbook.Worksheets.Add(sheetName);
 
-            PopulateSheet(worksheet, columns, rows);
+            PopulateSheet(worksheet, columns, rows, tableName, tableStyle);
 
             return package;
         }


### PR DESCRIPTION
package.Workbook.Worksheets.Add does not use the sheetName passed from GeneratePackage.
PopulateSheet from GeneratePackage does not pass tableName and tableSyle. @volkanceylan 