### PR TITLE
Output option for PdfExportOptions

### DIFF
--- a/Serene/Serene.Web/Modules/Common/Reporting/PdfExportHelper.ts
+++ b/Serene/Serene.Web/Modules/Common/Reporting/PdfExportHelper.ts
@@ -11,7 +11,8 @@
         fileName?: string;
         pageNumbers?: boolean;
         columnTitles?: { [key: string]: string };
-        tableOptions?: jsPDF.AutoTableOptions
+        tableOptions?: jsPDF.AutoTableOptions;
+        output?: string;
     }
 
     export namespace PdfExportHelper {
@@ -165,7 +166,15 @@
                     fileName = Q.format(fileName, g.getTitle() || "report",
                         Q.formatDate(new Date(), "yyyyMMdd_HHmm"));
 
-                    doc.save(fileName);
+                    if (options.output === undefined || options.output == "file")
+                        doc.save(fileName);
+
+                    if (options.output == "window-print" || options.output == "newwindow-print")
+                        doc.autoPrint();
+                    if (options.output == "newwindow" || options.output == "newwindow-print")
+                        doc.output('dataurlnewwindow');
+                    if (options.output == "window" || options.output == "window-print")
+                        doc.output('dataurl');
                 }
             }); 
         }


### PR DESCRIPTION
@volkanceylan

I have added an output parameter in options per PDFExport.

The possible values are:
* file (or null are default)
* window
* window-print
* newwindow
* newwindow-print

The window e newwindow values open generated PDF in current or in new browser tab.
The -print version open the PDF and automatically open the print dialog.

The file value (or not passed value) has the standard download action.