### PR TITLE
Update ReportDialog.ts to show report parameters in propertygrid

### DIFF
--- a/Serene/Serene.Web/Modules/Common/Reporting/ReportDialog.ts
+++ b/Serene/Serene.Web/Modules/Common/Reporting/ReportDialog.ts
@@ -23,7 +23,7 @@ namespace Serene.Common {
             this.propertyGrid = new Serenity.PropertyGrid(this.byId('PropertyGrid'), {
                 idPrefix: this.idPrefix,
                 useCategories: true,
-                items: this.propertyItems
+                items: this.report.Properties
             }).init(null);
         }
 


### PR DESCRIPTION
The property grid is blank when viewing 'CustomerGrossSalesReport'.
this.propertyItems should be this.report.Properties
After the change, 'Start Date' and 'End Date' appear and are respected report parameters.