### PR TITLE
Update PdfExportHelper.ts; Within pdfExportOptions,fileName is not respected 

### DIFF
--- a/Serene/Serene.Core/Modules/Common/Reporting/PdfExportHelper.ts
+++ b/Serene/Serene.Core/Modules/Common/Reporting/PdfExportHelper.ts
@@ -182,13 +182,35 @@ namespace Serene.Common {
                     }
 
 
-                    if (!options.output || options.output == "file") {
-                        var fileName = options.reportTitle || "{0}_{1}.pdf";
-                        fileName = Q.format(fileName, g.getTitle() || "report",
-                            Q.formatDate(new Date(), "yyyyMMdd_HHmm"));
+                        if (!options.output || options.output == "file") {
+                        let fileName = '';
+                        // *** Check if there has been given a fileName within the pdfExportOptions ***
+                        if (options.fileName) {
+                            // *** Yes, filename has been given, use this ***
+                            fileName = options.fileName;
+                        }
+                        else
+                        {
+                            // *** No fileName given with pdfExportOptions, calculate filename ***
+                            // *** Check if the reportTitle already contains the ".pdf" extension ***
+                            if (options.reportTitle.lastIndexOf(".pdf") == options.reportTitle.length-4) {
+                                // *** ReportTitle contains already the .pdf extension, so just use the reportTitle for fileName ***
+                                fileName = options.reportTitle;
+                            }
+                            else {
+                            // *** Add the ".pdf" extension to the fileName ***
+                                fileName = options.reportTitle + ".pdf";
+                            }
+                            
+                            // *** This seems to have no effect so I commented this out ***
+                            //fileName = Q.format(fileName, g.getTitle() || "report",
+                            //    Q.formatDate(new Date(), "yyyyMMdd_HHmm"));
+                        }
+                        
                         doc.save(fileName);
                         return;
                     }
+
 
                     if (options.autoPrint)
                         doc.autoPrint();


### PR DESCRIPTION
Good evening @volkanceylan 

within current pdfExportHelper.ts (within Serene), the fileName property of the pdfExportOptions is not respected/used at all. Also the use of reportTitle for the filename is "Buggy" as it requires the reportTitle to be set to xxx.pdf - otherwise the generated file will have no .PDF Extension and will not open in the web browser.

This pull request fixes These issues.

With Kind regards,

John
