### PR TITLE
Marketplace format has changed again. Now query extension without HTML scraping

### DIFF
--- a/Wizard/index.js
+++ b/Wizard/index.js
@@ -128,12 +128,21 @@ if (!fs.existsSync(cacheDir))
 
 console.log('Reading latest template version from VSGallery...');
 
-https.get({
+// The following post data reflects that which is sent via XHR when using web UI. I have not attempted to reduce this to the strictly necessary values.
+var postdata = JSON.stringify({"assetTypes":null,"filters":[{"criteria":[{"filterType":7,"value":"VolkanCeylan.SereneSerenityApplicationTemplate"}],"direction":2,"pageSize":100,"pageNumber":1,"sortBy":0,"sortOrder":0,"pagingToken":null}],"flags":71});
+
+var req = https.request({
+	method: 'POST',
     host: 'marketplace.visualstudio.com',
-    path: '/items?itemName=VolkanCeylan.SereneSerenityApplicationTemplate',
+    path: '/_apis/public/gallery/extensionquery',
     port: 443,
-    headers: { 'user-agent': 'Mozilla/5.0' }
+    headers: {
+    	'accept': 'application/json;api-version=5.1-preview.1;excludeUrls=true',
+		'content-type': 'application/json',
+		'content-length': postdata.length
+	}
 }, function(res) {
+
     if (!(res.statusCode >= 200 && res.statusCode <= 300)) {
         console.error("Couldn't read template page from VSGallery. Got status code " + res.statusCode);
         process.exit();
@@ -142,35 +151,31 @@ https.get({
     var str = "";
     res.on('data', function(d) { str += d; });
     res.on('end', function() {
-        var searchStart = '<script class="jiContent" defer="defer" type="application/json">';
-        var searchEnd = '</script>';
-        var idx = str.indexOf(searchStart);
-        if (idx <= 0) {
-            console.error("Couldn't read template version from VSGallery. Search string start: '" + searchStart + "' not found!");
-            process.exit();
-        }
 
-        var idx2 = str.indexOf(searchEnd, idx);
-        if (idx2 <= 0 || (idx2 - idx <= 20)) {
-            console.error("Couldn't read template version from VSGallery.");
-            process.exit();
-        }
-
-        var json = str.substring(idx + searchStart.length, idx2).trim();
-        if (!json.startsWith('{') || !json.endsWith('}')) {
+        try {
+            var data = JSON.parse(str);
+        } catch (error) {
             console.error("Couldn't read template version from VSGallery. Invalid JSON.");
             process.exit();
         }
 
-        var data = JSON.parse(json);
-        if (!data.Resources || !data.Resources.Version) {
+        if (!(data && data.results && data.results.length === 1 && data.results[0].extensions && data.results[0].extensions.length === 1)) {
+            console.error("Couldn't read template version from VSGallery. Invalid template data.");
+            process.exit();
+        }
+
+        var ext = data.results[0].extensions[0]; // extract first extension from results data
+
+        if (!(ext.versions && ext.versions.length > 0)) {
             console.error("Couldn't read template version from VSGallery. No version data.");
             process.exit();
         }
 
-        var version = data.Resources.Version;
+        var ext_ver = ext.versions[0]; // extract first version from extension versions
 
-        if (!data.AssetUri) {
+        var version = ext_ver.version;
+
+        if (!ext_ver.assetUri) {
             console.error("Couldn't read template version from VSGallery. No asset URI.");
             process.exit();
         }
@@ -182,11 +187,11 @@ https.get({
             useCacheZip(cacheZip);
         }
         else {
-            var assetSource = data.AssetUri + "/Serene.Template.vsix";
+            var assetSource = ext_ver.assetUri + "/Serene.Template.vsix";
             var oldFiles = fs.readdirSync(cacheDir).filter(function(x) { 
                 return x.toLowerCase().startsWith('Serene.Template.') && x.toLowerCase().endsWith('.vsix');
             });
-            console.log('Downloading latest Serene template...');
+            console.log('Downloading latest Serene template... from ' + assetSource);
             downloadHttps(assetSource, function(buffer) {
                     console.log('Download complete.');
                     fs.writeFileSync(cacheZip, buffer);
@@ -199,9 +204,17 @@ https.get({
         }
     });
 
-}).on('error', function(e) {
+});
+
+req.on('error', function(e) {
     console.log("Error while downloading template information: " + e.message);
 });
+
+req.write(
+    postdata
+);
+
+req.end();
 
 function PathMatcher(includesStr, excludesStr) {
 


### PR DESCRIPTION
Hi, it seems the Microsoft Marketplace format has changed again. Rather than being included in the HTML page, the data that Serin wizard looks up is now delivered via XHR 'extension query'.

Also, the format of the data seems to have changed. I have reworked the destructuring into what I believe is equivalent.
