### PR TITLE
Text returned by formatter should be html encoded

### DIFF
--- a/Serene/Serene.Web/Modules/Northwind/Customer/EmployeeListFormatter.ts
+++ b/Serene/Serene.Web/Modules/Northwind/Customer/EmployeeListFormatter.ts
@@ -9,7 +9,7 @@
 
             var byId = EmployeeRow.getLookup().itemById;
             let z: EmployeeRow;
-            return idList.map(x => ((z = byId[x]) ? z.FullName : x)).join(", ");
+            return Q.htmlEncode(idList.map(x => ((z = byId[x]) ? z.FullName : x)).join(", "));
         }
     }
 }


### PR DESCRIPTION
If not, you get strange results if the text contains some special chars (like " & < >).
Other formatters in the template seem to be ok, but not this one.